### PR TITLE
Hide volume slider on small screens

### DIFF
--- a/script.js
+++ b/script.js
@@ -476,7 +476,12 @@ function filterVerbTypes() {
 
 const musicToggle = document.getElementById('music-toggle');
 const volumeSlider = document.getElementById('volume-slider');
-volumeSlider.value = targetVolume;  
+const isMobile = window.matchMedia('(max-width: 768px)').matches;
+
+if (isMobile) {
+  volumeSlider.style.display = 'none';
+}
+volumeSlider.value = targetVolume;
 volumeSlider.addEventListener('input', () => {
   targetVolume = parseFloat(volumeSlider.value);
   music.volume = targetVolume;
@@ -1666,10 +1671,12 @@ function startTimerMode() {
     music.volume = 0;                // reinicia a 0
     music.play();
 
-    musicToggle.style.display = 'block';
-    volumeSlider.style.display = 'block';
-    volumeSlider.value = targetVolume;
-    volumeSlider.disabled = false;
+    if (!isMobile) {
+      musicToggle.style.display = 'block';
+      volumeSlider.style.display = 'block';
+      volumeSlider.value = targetVolume;
+      volumeSlider.disabled = false;
+    }
   }, 3000);
 
   prepareNextQuestion();
@@ -1968,11 +1975,13 @@ updateGameTitle(); // Para que muestre las vidas
   setTimeout(() => {
     music.volume = 0;                // reinicia a 0
     music.play();
- 
-    musicToggle.style.display = 'block';
-    volumeSlider.style.display = 'block';
-    volumeSlider.value = targetVolume;
-    volumeSlider.disabled = false;
+
+    if (!isMobile) {
+      musicToggle.style.display = 'block';
+      volumeSlider.style.display = 'block';
+      volumeSlider.value = targetVolume;
+      volumeSlider.disabled = false;
+    }
   }, 3000);
 
   prepareNextQuestion(); 

--- a/style.css
+++ b/style.css
@@ -1014,9 +1014,13 @@ button:active {
     right: 10px;
     padding: 8px 14px;
     font-size: 24px;
-	display: none;
+        display: none;
   }
-  
+  /* Hide the volume slider on small screens */
+  #volume-slider {
+    display: none !important;
+  }
+
 }
   @media (min-width: 900px) {
   .glitch-title {


### PR DESCRIPTION
## Summary
- hide volume slider via CSS when viewport is small
- detect small screens in JS and avoid showing the slider in game start logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842382bccd48327bea7aa60901b5430